### PR TITLE
Reverting The Nyanocombat 2 Rework On Drills

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -11,6 +11,7 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
+    # Grimbly #47, Reverting The Nyanocombat 2 Rework On Drills
     attackRate: 0.7
     range: 1.25
     wideAnimationRotation: -135
@@ -21,16 +22,16 @@
     damage:
       types:
         Blunt: 2
-        Pierce: 2
-    bluntStaminaDamageFactor: 2.0
-    heavyDamageBaseModifier: 1.75
+        Pierce: 3
+    bluntStaminaDamageFactor: 1.0
+    heavyDamageBaseModifier: 1
     heavyStaminaCost: 0
-    angle: 120
+    maxTargets: 3
+    angle: 100
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 1
         Structural: 30
   - type: Item
     size: Normal
@@ -60,16 +61,17 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
+    # Grimbly #47, Reverting The Nyanocombat 2 Rework On Drills
     attackRate: 3.5
     range: 1.4
     damage:
       types:
         Blunt: 1
-        Slash: 1
-        Structural: 12
-    bluntStaminaDamageFactor: 4.0
+        Slash: 2
+        Structural: 15
+    bluntStaminaDamageFactor: 1.0
     heavyRateModifier: 1
-    heavyRangeModifier: 2
+    heavyRangeModifier: 1
     heavyDamageBaseModifier: 1
     heavyStaminaCost: 0
     maxTargets: 3

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -11,8 +11,8 @@
     sprite: Objects/Weapons/Melee/pickaxe.rsi
     state: pickaxe
   - type: MeleeWeapon
-    attackRate: 0.75
-    range: 1.75
+    attackRate: 0.7
+    range: 1.25
     wideAnimationRotation: -135
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -24,9 +24,8 @@
         Pierce: 3
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
-    heavyStaminaCost: 5
-    maxTargets: 2
-    angle: 60
+    heavyStaminaCost: 0
+    angle: 120
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -61,7 +60,7 @@
     wideAnimationRotation: -90
     soundHit:
       path: "/Audio/Items/drill_hit.ogg"
-    attackRate: 0.5
+    attackRate: 3.5
     range: 1.4
     damage:
       types:
@@ -72,7 +71,7 @@
     heavyRateModifier: 1
     heavyRangeModifier: 2
     heavyDamageBaseModifier: 1
-    heavyStaminaCost: 10
+    heavyStaminaCost: 0
     maxTargets: 3
     angle: 20
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/pickaxe.yml
@@ -20,8 +20,8 @@
         volume: -3
     damage:
       types:
-        Blunt: 6
-        Pierce: 3
+        Blunt: 2
+        Pierce: 2
     bluntStaminaDamageFactor: 2.0
     heavyDamageBaseModifier: 1.75
     heavyStaminaCost: 0
@@ -30,7 +30,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 5
+        Blunt: 1
         Structural: 30
   - type: Item
     size: Normal
@@ -64,8 +64,8 @@
     range: 1.4
     damage:
       types:
-        Blunt: 9
-        Slash: 3
+        Blunt: 1
+        Slash: 1
         Structural: 12
     bluntStaminaDamageFactor: 4.0
     heavyRateModifier: 1


### PR DESCRIPTION
## About the PR
Removed the abysmal dogshit stamina drain on drills and pickaxes, I aint fucking clicking on every single damn rock, neither are you.

## Why / Balance
RSI and carpal tunnel lmao

## Requirements
im wanted by 7 nations, and one more is going to be added if these requirements are not removed
- [X] I have read and I am following the [Pull Request Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html). I understand that not doing so may get my pr closed at maintainer’s discretion
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**

:cl: Mocho
- tweak: Reverted the nerf on drills and pickaxes, they now work like they used to before the combat rebalance.

