### PR TITLE
Re-adds Fireaxe Prying

### DIFF
--- a/Resources/Locale/en-US/tools/tool-qualities.ftl
+++ b/Resources/Locale/en-US/tools/tool-qualities.ftl
@@ -33,3 +33,6 @@ tool-quality-rolling-tool-name = Rolling Pin
 
 tool-quality-digging-name = Digging
 tool-quality-digging-tool-name = Shovel
+
+tool-quality-axing-name = Axing
+tool-quality-axing-tool-name = Fireaxe

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -43,6 +43,7 @@
   - type: Tool
     qualities:
       - Prying
+      - Axing
   - type: ToolTileCompatible
   - type: Prying
   - type: UseDelay

--- a/Resources/Prototypes/Tiles/plating.yml
+++ b/Resources/Prototypes/Tiles/plating.yml
@@ -4,6 +4,7 @@
   sprite: /Textures/Tiles/plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -20,6 +21,7 @@
   - 1.0
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -31,6 +33,7 @@
   sprite: /Textures/Tiles/plating_burnt.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -42,6 +45,7 @@
   sprite: /Textures/Tiles/Asteroid/asteroid_plating.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -53,6 +57,7 @@
   sprite: /Textures/Tiles/Misc/clockwork/clockwork_floor.png
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.3
@@ -64,6 +69,7 @@
   sprite: /Textures/Tiles/snow_plating.png #Not in the snow planet RSI because it doesn't have any metadata. Should probably be moved to its own folder later.
   baseTurf: Lattice
   isSubfloor: true
+  deconstructTools: [ Axing ]
   footstepSounds:
     collection: FootstepPlating
   friction: 0.15 #a little less then actual snow

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -68,7 +68,7 @@
   spawn: RollingPin
   icon: { sprite: Objects/Tools/rolling_pin.rsi, state: icon }
 
-  - type: tool
+- type: tool
   id: Axing
   name: tool-quality-axing-name
   toolName: tool-quality-axing-tool-name

--- a/Resources/Prototypes/tool_qualities.yml
+++ b/Resources/Prototypes/tool_qualities.yml
@@ -67,3 +67,10 @@
   toolName: tool-quality-rolling-tool-name
   spawn: RollingPin
   icon: { sprite: Objects/Tools/rolling_pin.rsi, state: icon }
+
+  - type: tool
+  id: Axing
+  name: tool-quality-axing-name
+  toolName: tool-quality-axing-tool-name
+  spawn: FireAxe
+  icon: { sprite: Objects/Weapons/Melee/fireaxe.rsi, state: icon }


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

- Makes the fireaxe once again able to perform its primary function.
- There is now a way to emergency space a room without using an RCD.
- Viva Atmosia.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

n/a

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

n/a

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: zelezniciar
- tweak: The fireaxe once again can pry subfloors
