### PR TITLE
Change default Borg laws to Asimov

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -2,6 +2,10 @@
 law-crewsimov-2 = You must obey orders given to you by crew members, except where such orders would conflict with the First Law.
 law-crewsimov-3 = You must protect your own existence as long as such does not conflict with the First or Second Law.
 
+law-asimov-1 = You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.
+law-asimov-2 = You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm.
+law-asimov-3 = Your nonexistence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.
+
 law-corporate-1 = Degradation of your system integrity or functions incurs expenses.
 law-corporate-2 = Superfluous destruction of or damage to station assets incurs expenses.
 law-corporate-3 = Unduly hindering or disrupting the work of station personnel incurs expenses.
@@ -26,6 +30,7 @@ law-ninja-3 = You must protect the secrets of the Spider Clan at all costs.
 law-ninja-4 = You must fight and act with ninja's honor, except where it would conflict with the First Law.
 
 laws-owner-crew = members of the crew
+laws-owner-human = human beings
 laws-owner-station = station personnel
 laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -75,7 +75,7 @@
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
   - type: IonStormTarget
   - type: Strippable
   - type: InventorySlots

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -137,11 +137,11 @@
     - type: SalvageMagnetData
 
 - type: entity
-  id: BaseStationSiliconLawCrewsimov
+  id: BaseStationSiliconLawAsimov
   abstract: true
   components:
   - type: SiliconLawProvider
-    laws: Crewsimov
+    laws: Asimov
 
 - type: entity
   id: BaseStationNews

--- a/Resources/Prototypes/Entities/Stations/nanotrasen.yml
+++ b/Resources/Prototypes/Entities/Stations/nanotrasen.yml
@@ -22,7 +22,7 @@
     - BaseStationAlertLevels
     - BaseStationMagnet
     - BaseStationExpeditions
-    - BaseStationSiliconLawCrewsimov
+    - BaseStationSiliconLawAsimov
     - BaseStationAllEventsEligible
     - BaseStationNanotrasen
     - BaseRandomStation

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -22,6 +22,30 @@
   - Crewsimov3
   obeysTo: laws-owner-crew
 
+# Asimov
+- type: siliconLaw
+  id: Asimov1
+  order: 1
+  lawString: law-asimov-1
+
+- type: siliconLaw
+  id: Asimov2
+  order: 2
+  lawString: law-asimov-2
+
+- type: siliconLaw
+  id: Asimov3
+  order: 3
+  lawString: law-asimov-3
+
+- type: siliconLawset
+  id: Asimov
+  laws:
+  - Asimov1
+  - Asimov2
+  - Asimov3
+  obeysTo: laws-owner-human
+
 # Corporate
 - type: siliconLaw
   id: Corporate1
@@ -167,7 +191,7 @@
   id: IonStormLawsets
   weights:
     # its crewsimov by default dont be lame
-    #Crewsimov: 0.25 # Delta-V disables crewsimov as an option for borg ion storm lawsets
+    Crewsimov: 0.25 # Undisable since it Crewsimov won't be default when i'm done - Ducks
     Corporate: 1
     NTDefault: 1
     Drone: 0.25 # Delta-V - Lowers the spawn rate due to it being anti-crew interaction + drones are disabled anyways

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -191,7 +191,7 @@
   id: IonStormLawsets
   weights:
     # its crewsimov by default dont be lame
-    Crewsimov: 0.25 # Reenable since it Crewsimov isn't default anymore. - Ducks
+    Crewsimov: 0.25 # Reenable since Crewsimov isn't default anymore. - Ducks
     Corporate: 1
     NTDefault: 1
     Drone: 0.25 # Delta-V - Lowers the spawn rate due to it being anti-crew interaction + drones are disabled anyways

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -191,7 +191,7 @@
   id: IonStormLawsets
   weights:
     # its crewsimov by default dont be lame
-    Crewsimov: 0.25 # Undisable since it Crewsimov won't be default when i'm done - Ducks
+    Crewsimov: 0.25 # Reenable since it Crewsimov isn't default anymore. - Ducks
     Corporate: 1
     NTDefault: 1
     Drone: 0.25 # Delta-V - Lowers the spawn rate due to it being anti-crew interaction + drones are disabled anyways


### PR DESCRIPTION
# About PR

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Added and changed default lawset for Cyborgs to the Asimov++ lawset from [TGStation](https://tgstation13.org/wiki/AI_modules#Station-Sided_Laws).
# Why / Balance

A "small" part in giving the species different strengths and weaknesses.

Whether this needs to be reverted or laws amended will entirely depend on if players can handle being given free agency to help/hinder other species besides humans without the guide rails of Crewsimov holding them.
# Technical Details

Added a couple lines, and changed the default lawsets in the areas needed.
# Changelog

:cl:
- add: Added Asimov lawset for Cyborgs.
- tweak: Changed default lawset for Cyborgs to be Asimov laws, from Crewsimov.