### PR TITLE
Make Rat King more Neutral

### DIFF
--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -65,7 +65,7 @@ ghost-role-information-kobold-name = Kobold
 ghost-role-information-kobold-description = Be the little gremlin you are, yell at people and beg for meat!
 
 ghost-role-information-rat-king-name = Rat King
-ghost-role-information-rat-king-description = You are da Rat King, you make da roolz.
+ghost-role-information-rat-king-description = You are the Rat King, scavenge food in order to produce rat minions to do your bidding
 ghost-role-information-rat-king-rules =  You have no allegiance, so scavenge, attack, and grow your hoard or learn to live in peace with the crew. 
 
 ghost-role-information-rat-servant-name = Rat Servant

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -65,7 +65,8 @@ ghost-role-information-kobold-name = Kobold
 ghost-role-information-kobold-description = Be the little gremlin you are, yell at people and beg for meat!
 
 ghost-role-information-rat-king-name = Rat King
-ghost-role-information-rat-king-description = You are da Rat King, you make da roolz. You have no allegiance, scavenge, attack, and grow your hoard or learn to live in peace with the crew.
+ghost-role-information-rat-king-description = You are da Rat King, you make da roolz.
+ghost-role-information-rat-king-rules =  You have no allegiance, so scavenge, attack, and grow your hoard or learn to live in peace with the crew. 
 
 ghost-role-information-rat-servant-name = Rat Servant
 ghost-role-information-rat-servant-description = You are a Rat Servant. You must follow your king's orders.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -65,8 +65,7 @@ ghost-role-information-kobold-name = Kobold
 ghost-role-information-kobold-description = Be the little gremlin you are, yell at people and beg for meat!
 
 ghost-role-information-rat-king-name = Rat King
-ghost-role-information-rat-king-description = You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
-ghost-role-information-rat-king-rules = You are an antagonist, scavenge, attack, and grow your hoard!
+ghost-role-information-rat-king-description = You are da Rat King, you make da roolz. You have no allegiance, scavenge, attack, and grow your hoard or learn to live in peace with the crew.
 
 ghost-role-information-rat-servant-name = Rat Servant
 ghost-role-information-rat-servant-description = You are a Rat Servant. You must follow your king's orders.

--- a/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/ghost/roles/ghost-role-component.ftl
@@ -65,7 +65,7 @@ ghost-role-information-kobold-name = Kobold
 ghost-role-information-kobold-description = Be the little gremlin you are, yell at people and beg for meat!
 
 ghost-role-information-rat-king-name = Rat King
-ghost-role-information-rat-king-description = You are the Rat King, scavenge food in order to produce rat minions to do your bidding
+ghost-role-information-rat-king-description = You are the Rat King, scavenge food in order to produce rat minions to do your bidding.
 ghost-role-information-rat-king-rules =  You have no allegiance, so scavenge, attack, and grow your hoard or learn to live in peace with the crew. 
 
 ghost-role-information-rat-servant-name = Rat Servant

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -2,7 +2,7 @@
   name: Rat King
   id: MobRatKing
   parent: [ SimpleMobBase, MobCombat ]
-  description: He's da rat. He make da roolz.
+  description: He's da rat king. He make da roolz.
   components:
   - type: CombatMode
   - type: MovementSpeedModifier
@@ -42,6 +42,19 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  - type: Hands
+  - type: Inventory
+    speciesId: ratking
+    templateId: ratking
+  - type: InventorySlots
+  - type: Strippable
+  - type: UserInterface
+    interfaces:
+    - key: enum.StrippingUiKey.Key
+      type: StrippableBoundUserInterface
+  - type: Puller
+    needsHands: false
+  - type: IdExaminable
   - type: MobState
   - type: MobThresholds
     thresholds:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Rat King
   id: MobRatKing
-  parent: [ SimpleMobBase, MobCombat ]
+  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase ] #Grimbly - ratking ID and headset
   description: He's da rat king. He make da roolz.
   components:
   - type: CombatMode
@@ -42,16 +42,13 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
-  - type: Hands
+  - type: ComplexInteraction #Grimbly - ratking ID and headset
   - type: Inventory
     speciesId: ratking
     templateId: ratking
   - type: InventorySlots
   - type: Strippable
   - type: UserInterface
-    interfaces:
-    - key: enum.StrippingUiKey.Key
-      type: StrippableBoundUserInterface
   - type: Puller
     needsHands: false
   - type: IdExaminable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: Rat King
   id: MobRatKing
-  parent: [ SimpleMobBase, MobCombat, StripableInventoryBase ] #Grimbly - ratking ID and headset
+  parent: [ SimpleMobBase, MobCombat ] 
   description: He's da rat king. He make da roolz.
   components:
   - type: CombatMode
@@ -49,6 +49,9 @@
   - type: InventorySlots
   - type: Strippable
   - type: UserInterface
+    interfaces:
+    - key: enum.StrippingUiKey.Key
+      type: StrippableBoundUserInterface
   - type: Puller
     needsHands: false
   - type: IdExaminable

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -42,7 +42,7 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
-  - type: ComplexInteraction #Grimbly - ratking ID and headset
+  - type: Hands #Grimbly - ratking ID and headset
   - type: Inventory
     speciesId: ratking
     templateId: ratking

--- a/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/rat_king_inventory_template.yml
@@ -1,0 +1,18 @@
+- type: inventoryTemplate
+  id: ratking
+  slots:
+  - name: ears
+    slotTexture: ears
+    slotFlags: EARS
+    stripTime: 3
+    uiWindowPos: 0,2
+    strippingWindowPos: 1,2
+    displayName: Ears
+  - name: id
+    slotTexture: id
+    slotFlags: IDCARD
+    slotGroup: SecondHotbar
+    stripTime: 6
+    uiWindowPos: 0,1
+    strippingWindowPos: 2,4
+    displayName: ID


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Because community vote requested to keep Rat Kings as they are, this PR should give neutral and friendly Rat Kings more RP options.

- Gives Rat King a PDA and headset slot
- Lets Rat King drag objects
- Changes Rules and Description to clarify that you are not required to act as an antag.

Addresses #93 

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![obrázok](https://github.com/user-attachments/assets/68e60a4e-5c63-477c-8e9d-5e274e128f23)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl: zelezniciar
- tweak: Rat Kings now have PDA and Headset slots, and can drag objects.
