### PR TITLE
Corpsman&sec loadout hotfix

### DIFF
--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -808,6 +808,76 @@
   items:
     - MagazinePistolRubber
 
+##For the N1984 - Tmanz
+- type: loadout
+  id: LoadoutMagazineMagnum
+  category: JobsSecurity
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEquipmentSecurity
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - MagazineMagnum
+
+- type: loadout
+  id: LoadoutMagazineMagnumRubber
+  category: JobsSecurity
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEquipmentSecurity
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - MagazineMagnumRubber
+
+    - type: loadout
+  id: LoadoutMagazineMagnumSpare
+  category: JobsSecurity
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEquipmentSecurity
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - MagazineMagnum
+
+- type: loadout
+  id: LoadoutMagazineMagnumRubberSpare
+  category: JobsSecurity
+  cost: 2
+  exclusive: true
+  requirements:
+    - !type:CharacterDepartmentTimeRequirement
+      department: Security
+      min: 3600 # 1 hours
+    - !type:CharacterItemGroupRequirement
+      group: LoadoutEquipmentSecurity
+    - !type:CharacterDepartmentRequirement
+      departments:
+        - Security
+  items:
+    - MagazineMagnumRubber
+##End N1984 Additions
+
 - type: loadout
   id: LoadoutSpeedLoaderMagnum
   category: JobsSecurity

--- a/Resources/Prototypes/Loadouts/Jobs/security.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/security.yml
@@ -843,7 +843,7 @@
   items:
     - MagazineMagnumRubber
 
-    - type: loadout
+- type: loadout
   id: LoadoutMagazineMagnumSpare
   category: JobsSecurity
   cost: 2

--- a/Resources/Prototypes/Loadouts/backpacks.yml
+++ b/Resources/Prototypes/Loadouts/backpacks.yml
@@ -57,7 +57,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackBrigmedic
+    - ClothingBackpackBrigmedicFilled
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBackpacks

--- a/Resources/Prototypes/Loadouts/duffelbags.yml
+++ b/Resources/Prototypes/Loadouts/duffelbags.yml
@@ -43,7 +43,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackDuffelBrigmedic
+    - ClothingBackpackDuffelBrigmedicFilled
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBackpacks

--- a/Resources/Prototypes/Loadouts/satchels.yml
+++ b/Resources/Prototypes/Loadouts/satchels.yml
@@ -56,7 +56,7 @@
   cost: 0
   exclusive: true
   items:
-    - ClothingBackpackSatchelBrigmedic
+    - ClothingBackpackSatchelBrigmedicFilled
   requirements:
     - !type:CharacterItemGroupRequirement
       group: LoadoutBackpacks


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Makes corpsman loadout duffels, satchels, and backpacks start with correct items.
Also gives N1984 Spare magazines in Security Loadouts, for a price.
---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [x] Fixed corpsman loadout duffels, satchels, and backpacks to start filled with their respective items.
- [x] Gave N1984 more magazines in loadouts, for a price.

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- add: Gave N1984 more magazines in loadouts, for a price.
- fix: Fixed corpsman loadout duffels, satchels, and backpacks to start filled with their respective items.

